### PR TITLE
Adapt to beta 31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-opengl</artifactId>
 		</dependency>
+		<!-- LWJGL natives -->
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
@@ -88,6 +89,7 @@
 			<artifactId>lwjgl-opengl</artifactId>
 			<classifier>${lwjgl.natives}</classifier>
 		</dependency>
+		<!-- LWJGL AWT -->
 		<dependency>
 			<groupId>org.lwjglx</groupId>
 			<artifactId>lwjgl3-awt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
 
+		<mastodon.version>1.0.0-beta-31-SNAPSHOT</mastodon.version>
+
 		<lwjgl.version>3.3.1</lwjgl.version>
 		<lwjgl3-awt.version>0.1.8</lwjgl3-awt.version>
 		<lwjgl.natives>natives-macos</lwjgl.natives>
@@ -54,6 +56,15 @@
 	</dependencyManagement>
 
 	<dependencies>
+
+		<!-- Mastodon Core -->
+		<dependency>
+			<groupId>org.mastodon</groupId>
+			<artifactId>mastodon</artifactId>
+			<version>${mastodon.version}</version>
+		</dependency>
+
+		<!-- LWJGL (lightweight java gaming library) for fast rendering of many points -->
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
@@ -82,11 +93,7 @@
 			<artifactId>lwjgl3-awt</artifactId>
 			<version>${lwjgl3-awt.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.mastodon</groupId>
-			<artifactId>mastodon</artifactId>
-			<version>1.0.0-beta-27-SNAPSHOT</version>
-		</dependency>
+
 	</dependencies>
 
 	<developers>

--- a/src/main/java/org/mastodon/grapher/opengl/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/grapher/opengl/InertialScreenTransformEventHandler.java
@@ -3,8 +3,9 @@ package org.mastodon.grapher.opengl;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.mastodon.ui.keymap.CommandDescriptionProvider;
-import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.mamut.KeyConfigScopes;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionProvider;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptions;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.views.grapher.datagraph.ScreenTransform;
 import org.mastodon.views.grapher.display.ConstrainScreenTransform;
@@ -54,7 +55,7 @@ public class InertialScreenTransformEventHandler
 	{
 		public Descriptions()
 		{
-			super( KeyConfigContexts.GRAPHER );
+			super( KeyConfigScopes.MAMUT, KeyConfigContexts.GRAPHER );
 		}
 
 		@Override

--- a/src/main/java/org/mastodon/grapher/opengl/MamutViewOpenGL.java
+++ b/src/main/java/org/mastodon/grapher/opengl/MamutViewOpenGL.java
@@ -6,9 +6,6 @@ import static org.mastodon.mamut.MamutMenuBuilder.colorMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
-import static org.mastodon.mamut.MamutViewStateSerialization.FEATURE_COLOR_MODE_KEY;
-import static org.mastodon.mamut.MamutViewStateSerialization.NO_COLORING_KEY;
-import static org.mastodon.mamut.MamutViewStateSerialization.TAG_SET_KEY;
 
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
@@ -26,9 +23,9 @@ import org.mastodon.app.ui.MastodonFrameViewActions;
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.mamut.MainWindow;
-import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.MamutMenuBuilder;
-import org.mastodon.mamut.MamutView;
+import org.mastodon.mamut.views.MamutView;
 import org.mastodon.mamut.UndoActions;
 import org.mastodon.mamut.feature.SpotPositionFeature;
 import org.mastodon.mamut.model.Link;
@@ -47,8 +44,9 @@ import org.mastodon.views.grapher.display.FeatureGraphConfig;
 import org.mastodon.views.grapher.display.FeatureGraphConfig.GraphDataItemsSource;
 import org.mastodon.views.grapher.display.FeatureSpecPair;
 import org.mastodon.views.grapher.display.style.DataDisplayStyle;
-import org.mastodon.views.trackscheme.display.ColorBarOverlay;
-import org.mastodon.views.trackscheme.display.ColorBarOverlay.Position;
+import org.mastodon.ui.coloring.ColorBarOverlay;
+import org.mastodon.ui.coloring.ColorBarOverlay.Position;
+import org.mastodon.views.grapher.display.style.DataDisplayStyleManager;
 import org.scijava.ui.behaviour.KeyPressedManager;
 
 public class MamutViewOpenGL extends MamutView< ViewGraph< Spot, Link, Spot, Link >, Spot, Link >
@@ -62,12 +60,12 @@ public class MamutViewOpenGL extends MamutView< ViewGraph< Spot, Link, Spot, Lin
 
 	private final ColorBarOverlay colorbarOverlay;
 
-	public MamutViewOpenGL( final MamutAppModel appModel )
+	public MamutViewOpenGL( final ProjectModel appModel )
 	{
 		this(appModel, new HashMap<>());
 	}
 	
-	public MamutViewOpenGL( final MamutAppModel appModel, final Map< String, Object > guiState )
+	public MamutViewOpenGL( final ProjectModel appModel, final Map< String, Object > guiState )
 	{
 		super( appModel,
 				createViewGraph( appModel ),
@@ -79,7 +77,8 @@ public class MamutViewOpenGL extends MamutView< ViewGraph< Spot, Link, Spot, Lin
 		final AutoNavigateFocusModel< Spot, Link > navigateFocusModel =
 				new AutoNavigateFocusModel<>( focusModel, navigationHandler );
 
-		final DataDisplayStyle forwardDefaultStyle = appModel.getDataDisplayStyleManager().getForwardDefaultStyle();
+		final DataDisplayStyleManager dataDisplayStyleManager = appModel.getWindowManager().getManager( DataDisplayStyleManager.class );
+		final DataDisplayStyle forwardDefaultStyle = dataDisplayStyleManager.getForwardDefaultStyle();
 		coloringAdapter = new GraphColorGeneratorAdapter<>( viewGraph.getVertexMap(), viewGraph.getEdgeMap() );
 		final DataDisplayOptions options = DataDisplayOptions.options()
 				.shareKeyPressedEvents( keyPressedManager )
@@ -228,7 +227,7 @@ public class MamutViewOpenGL extends MamutView< ViewGraph< Spot, Link, Spot, Lin
 		getFrame().repaint();
 	}
 
-	private static ViewGraph< Spot, Link, Spot, Link > createViewGraph( final MamutAppModel appModel )
+	private static ViewGraph< Spot, Link, Spot, Link > createViewGraph( final ProjectModel appModel )
 	{
 		return IdentityViewGraph.wrap( appModel.getModel().getGraph(), appModel.getModel().getGraphIdBimap() );
 	}

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudFrame.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudFrame.java
@@ -41,7 +41,7 @@ public class PointCloudFrame extends ViewFrame
 			final FeatureModel featureModel,
 			final int nSources,
 			final HighlightModel< Spot, Link > highlight,
-			final FocusModel< Spot, Link > focus,
+			final FocusModel< Spot > focus,
 			final SelectionModel< Spot, Link > selection,
 			final NavigationHandler< Spot, Link > navigation,
 			final UndoPointMarker undoPointMarker,

--- a/src/test/java/org/mastodon/grapher/opengl/TestGrapher.java
+++ b/src/test/java/org/mastodon/grapher/opengl/TestGrapher.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import javax.swing.JFrame;
 
 import org.mastodon.mamut.MainWindow;
-import org.mastodon.mamut.MamutAppModel;
-import org.mastodon.mamut.WindowManager;
-import org.mastodon.mamut.project.MamutProject;
-import org.mastodon.mamut.project.MamutProjectIO;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.ProjectLoader;
 import org.scijava.Context;
 
 import mpicbg.spim.data.SpimDataException;
@@ -19,16 +17,12 @@ public class TestGrapher
 	public static void main( final String[] args ) throws IOException, SpimDataException
 	{
 		final Context context = new Context();
-		final WindowManager wm = new WindowManager( context );
 //		final String projectPath = "/Users/tinevez/Google Drive/Mastodon/Datasets/Remote/FromVlado/mette_e1.mastodon";
 		final String projectPath = "../mastodon/samples/drosophila_crop.mastodon";
-		final MamutProject project = new MamutProjectIO().load( projectPath );
-		wm.getProjectManager().open( project );
-		new MainWindow( wm ).setVisible( true );
+		ProjectModel projectModel = ProjectLoader.open( projectPath, context );
+		new MainWindow( projectModel ).setVisible( true );
 
-		final MamutAppModel appModel = wm.getAppModel();
-
-		final MamutViewOpenGL grapher = new MamutViewOpenGL( appModel );
+		final MamutViewOpenGL grapher = new MamutViewOpenGL( projectModel );
 		grapher.getFrame().setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
 	}
 

--- a/src/test/java/org/mastodon/grapher/opengl/TestGrapherGlVsGrapher.java
+++ b/src/test/java/org/mastodon/grapher/opengl/TestGrapherGlVsGrapher.java
@@ -1,0 +1,31 @@
+package org.mastodon.grapher.opengl;
+
+import mpicbg.spim.data.SpimDataException;
+import org.mastodon.mamut.MainWindow;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.ProjectLoader;
+import org.mastodon.mamut.views.grapher.MamutViewGrapher;
+import org.scijava.Context;
+
+import javax.swing.JFrame;
+import java.io.IOException;
+
+public class TestGrapherGlVsGrapher
+{
+	public static void main( final String[] args ) throws IOException, SpimDataException
+	{
+		final Context context = new Context();
+		final String projectPath = "/Users/tinevez/Google Drive/Mastodon/Datasets/Remote/FromVlado/mette_e1.mastodon";
+		final ProjectModel projectModel = ProjectLoader.open( projectPath, context, false, true );
+		MainWindow mainWindow = new MainWindow( projectModel );
+		mainWindow.setVisible( true );
+		mainWindow.setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
+
+		final MamutViewOpenGL grapherOpenGL = new MamutViewOpenGL( projectModel );
+		grapherOpenGL.getFrame().setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
+
+		final MamutViewGrapher grapher = new MamutViewGrapher( projectModel );
+		grapher.getFrame().setVisible( true );
+		grapher.getFrame().setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
+	}
+}


### PR DESCRIPTION
This PR makes some required changes so that the grapher opengl can be used with the current version of Mastodon core (1.0.0.-beta-31-SNAPSHOT)

* Replace AppModel by new class ProjectModel
* Update Mamut View States import
* Update ColorbarOverlay import
* Update DataDisplayStyleManager
* Update FocusModel
* Use scijava CommandDescriptions classes instead of those from Mastodon

It also adds a 2nd class for demoing/testing, which opens the grapher and the grapherGl simultaneously for more straighforward feature and performance comparison.

Currently, this branch from Mastodon core is needed to run the GrapherGl: https://github.com/mastodon-sc/mastodon/tree/opengl-grapher-beta-31