### PR TITLE
Use background color from style settings in user preferences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>33.2.0</version>
+		<version>38.0.1</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>

--- a/src/main/java/org/mastodon/grapher/opengl/DataLayoutMaker.java
+++ b/src/main/java/org/mastodon/grapher/opengl/DataLayoutMaker.java
@@ -563,6 +563,11 @@ public class DataLayoutMaker implements ContextListener< Spot >
 		return ylabel;
 	}
 
+	public DataDisplayStyle getStyle()
+	{
+		return style;
+	}
+
 	private RefSet< Spot > fromContext()
 	{
 		final Iterable< Spot > iterable;

--- a/src/main/java/org/mastodon/grapher/opengl/DataLayoutMaker.java
+++ b/src/main/java/org/mastodon/grapher/opengl/DataLayoutMaker.java
@@ -1,7 +1,7 @@
 package org.mastodon.grapher.opengl;
 
-import static org.mastodon.grapher.opengl.overlays.DataPointsOverlay.COLOR_SIZE;
-import static org.mastodon.grapher.opengl.overlays.DataPointsOverlay.VERTEX_SIZE;
+import static org.mastodon.grapher.opengl.overlays.DataPointsOverlay.COLOR_NUM_CHANNELS;
+import static org.mastodon.grapher.opengl.overlays.DataPointsOverlay.VERTEX_NUM_DIMENSIONS;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -143,7 +143,7 @@ public class DataLayoutMaker implements ContextListener< Spot >
 		 * Vertex pos.
 		 */
 
-		final float[] xyPos = new float[ VERTEX_SIZE * vertices.size() ];
+		final float[] xyPos = new float[ VERTEX_NUM_DIMENSIONS * vertices.size() ];
 		if ( ( xpVertex != null || xpEdge != null ) && ( ypVertex != null || ypEdge != null ) )
 		{
 			int i = 0;
@@ -169,7 +169,7 @@ public class DataLayoutMaker implements ContextListener< Spot >
 		if ( paintEdges )
 		{
 			edgeIndices = new int[ edges.size() * 2 ];
-			edgePositions = new float[ edges.size() * 2 * VERTEX_SIZE ];
+			edgePositions = new float[ edges.size() * 2 * VERTEX_NUM_DIMENSIONS ];
 
 			final Spot sref = vertices.createRef();
 			final Spot tref = vertices.createRef();
@@ -248,7 +248,7 @@ public class DataLayoutMaker implements ContextListener< Spot >
 		 */
 
 		final int n = vertices.size();
-		final float[] vertexColors = new float[ COLOR_SIZE * n ];
+		final float[] vertexColors = new float[ COLOR_NUM_CHANNELS * n ];
 		final float[] tmp = new float[ 4 ];
 		int i = 0;
 		for ( final Spot spot : vertices )
@@ -281,7 +281,7 @@ public class DataLayoutMaker implements ContextListener< Spot >
 		int j = 0;
 		if ( paintEdges )
 		{
-			edgeColors = new float[ edges.size() * COLOR_SIZE * 2 ];
+			edgeColors = new float[ edges.size() * COLOR_NUM_CHANNELS * 2 ];
 			final Spot sref = vertices.createRef();
 			final Spot tref = vertices.createRef();
 			for ( final Link e : edges )
@@ -442,7 +442,7 @@ public class DataLayoutMaker implements ContextListener< Spot >
 	/**
 	 * Returns the set of data vertices that are painted according to this
 	 * layout instance, within the specified <b>screen coordinates</b>.
-	 * 
+	 *
 	 * @param x1
 	 *            x min in screen coordinates.
 	 * @param y1

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -49,9 +49,9 @@ public class PointCloudCanvas extends AWTGLCanvas
 	// TODO move into a style.
 	public static final Color BACKGROUND_COLOR = new Color( 204, 204, 204 );
 
-	private int framebufferWidth;
+	private int frameBufferWidth;
 
-	private int framebufferHeight;
+	private int frameBufferHeight;
 
 	/**
 	 * Mouse/Keyboard handler that manipulates the view transformation.
@@ -69,11 +69,11 @@ public class PointCloudCanvas extends AWTGLCanvas
 			final java.awt.geom.AffineTransform transform = PointCloudCanvas.this.getGraphicsConfiguration().getDefaultTransform();
 			final float sx = ( float ) transform.getScaleX();
 			final float sy = ( float ) transform.getScaleY();
-			framebufferWidth = ( int ) ( w * sx );
-			framebufferHeight = ( int ) ( h * sy );
+			frameBufferWidth = ( int ) ( w * sx );
+			frameBufferHeight = ( int ) ( h * sy );
 			overlayRenderers.list.forEach( r -> r.setCanvasSize( w, h ) );
 			if ( handler != null )
-				handler.setCanvasSize( framebufferWidth, framebufferHeight, true );
+				handler.setCanvasSize( frameBufferWidth, frameBufferHeight, true );
 		}
 	};
 
@@ -209,7 +209,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 		glMatrixMode( GL_PROJECTION );
 		glLoadIdentity();
 		glOrtho( transform.getMinX(), transform.getMaxX(), transform.getMinY(), transform.getMaxY(), -1, 1 );
-		glViewport( 0, 0, getFramebufferWidth(), getFramebufferHeight() );
+		glViewport( 0, 0, getFrameBufferWidth(), getFrameBufferHeight() );
 		glMatrixMode( GL_MODELVIEW );
 
 		overlayRenderers.list.forEach( GLOverlayRenderer::paint );
@@ -217,14 +217,14 @@ public class PointCloudCanvas extends AWTGLCanvas
 		swapBuffers();
 	}
 
-	public int getFramebufferWidth()
+	public int getFrameBufferWidth()
 	{
-		return framebufferWidth;
+		return frameBufferWidth;
 	}
 
-	public int getFramebufferHeight()
+	public int getFrameBufferHeight()
 	{
-		return framebufferHeight;
+		return frameBufferHeight;
 	}
 
 	public void setTransform( final ScreenTransform transform )

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -82,14 +82,14 @@ public class PointCloudCanvas extends AWTGLCanvas
 	/**
 	 * Used to read from the screen transform state.
 	 */
-	final ScreenTransform t;
+	final ScreenTransform transform;
 
 	public PointCloudCanvas()
 	{
 		super();
 		overlayRenderers = new Listeners.SynchronizedList<>( r -> r.setCanvasSize( getWidth(), getHeight() ) );
 
-		this.t = new ScreenTransform( -1, 1, -1, 1, 400, 400 );
+		this.transform = new ScreenTransform( -1, 1, -1, 1, 400, 400 );
 		this.addComponentListener( listener );
 		this.addMouseListener( new MouseAdapter()
 		{
@@ -208,7 +208,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 
 		glMatrixMode( GL_PROJECTION );
 		glLoadIdentity();
-		glOrtho( t.getMinX(), t.getMaxX(), t.getMinY(), t.getMaxY(), -1, 1 );
+		glOrtho( transform.getMinX(), transform.getMaxX(), transform.getMinY(), transform.getMaxY(), -1, 1 );
 		glViewport( 0, 0, getFramebufferWidth(), getFramebufferHeight() );
 		glMatrixMode( GL_MODELVIEW );
 
@@ -229,6 +229,6 @@ public class PointCloudCanvas extends AWTGLCanvas
 
 	public void setTransform( final ScreenTransform transform )
 	{
-		t.set( transform );
+		this.transform.set( transform );
 	}
 }

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -105,7 +105,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 
 	/**
 	 * OverlayRenderers can be added/removed here.
-	 * {@link GLOverlayRenderer#drawOverlays} is invoked for each renderer (in
+	 * {@link GLOverlayRenderer#paint()} is invoked for each renderer (in
 	 * the order they were added).
 	 */
 	public Listeners< GLOverlayRenderer > overlays()

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -87,9 +87,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 	public PointCloudCanvas()
 	{
 		super();
-		overlayRenderers = new Listeners.SynchronizedList<>( r -> {
-			r.setCanvasSize( getWidth(), getHeight() );
-		} );
+		overlayRenderers = new Listeners.SynchronizedList<>( r -> r.setCanvasSize( getWidth(), getHeight() ) );
 
 		this.t = new ScreenTransform( -1, 1, -1, 1, 400, 400 );
 		this.addComponentListener( listener );
@@ -196,7 +194,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 		glEnable( GL_BLEND );
 		glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
-		overlayRenderers.list.forEach( r -> r.init() );
+		overlayRenderers.list.forEach( GLOverlayRenderer::init );
 	}
 
 	@Override
@@ -214,7 +212,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 		glViewport( 0, 0, getFramebufferWidth(), getFramebufferHeight() );
 		glMatrixMode( GL_MODELVIEW );
 
-		overlayRenderers.list.forEach( r -> r.paint() );
+		overlayRenderers.list.forEach( GLOverlayRenderer::paint );
 
 		swapBuffers();
 	}

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -66,9 +66,9 @@ public class PointCloudCanvas extends AWTGLCanvas
 		{
 			final int w = getWidth();
 			final int h = getHeight();
-			final java.awt.geom.AffineTransform t = PointCloudCanvas.this.getGraphicsConfiguration().getDefaultTransform();
-			final float sx = ( float ) t.getScaleX();
-			final float sy = ( float ) t.getScaleY();
+			final java.awt.geom.AffineTransform transform = PointCloudCanvas.this.getGraphicsConfiguration().getDefaultTransform();
+			final float sx = ( float ) transform.getScaleX();
+			final float sy = ( float ) transform.getScaleY();
 			framebufferWidth = ( int ) ( w * sx );
 			framebufferHeight = ( int ) ( h * sy );
 			overlayRenderers.list.forEach( r -> r.setCanvasSize( w, h ) );

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -20,7 +20,6 @@ import static org.lwjgl.opengl.GL11.glOrtho;
 import static org.lwjgl.opengl.GL11.glViewport;
 import static org.lwjgl.opengl.GL11C.GL_DEPTH_BUFFER_BIT;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ComponentAdapter;
@@ -37,6 +36,7 @@ import java.awt.event.MouseWheelListener;
 import org.lwjgl.opengl.awt.AWTGLCanvas;
 import org.mastodon.grapher.opengl.overlays.GLOverlayRenderer;
 import org.mastodon.views.grapher.datagraph.ScreenTransform;
+import org.mastodon.views.grapher.display.style.DataDisplayStyle;
 import org.scijava.listeners.Listeners;
 
 import bdv.TransformEventHandler;
@@ -45,9 +45,6 @@ public class PointCloudCanvas extends AWTGLCanvas
 {
 
 	private static final long serialVersionUID = 1L;
-
-	// TODO move into a style.
-	public static final Color BACKGROUND_COLOR = new Color( 204, 204, 204 );
 
 	private int frameBufferWidth;
 
@@ -84,7 +81,9 @@ public class PointCloudCanvas extends AWTGLCanvas
 	 */
 	final ScreenTransform transform;
 
-	public PointCloudCanvas()
+	final DataDisplayStyle style;
+
+	public PointCloudCanvas(final DataDisplayStyle style )
 	{
 		super();
 		overlayRenderers = new Listeners.SynchronizedList<>( r -> r.setCanvasSize( getWidth(), getHeight() ) );
@@ -99,6 +98,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 				requestFocusInWindow();
 			}
 		} );
+		this.style = style;
 	}
 
 	/**
@@ -202,7 +202,7 @@ public class PointCloudCanvas extends AWTGLCanvas
 	{
 		createCapabilities();
 		final float[] gbColArr = new float[ 4 ];
-		BACKGROUND_COLOR.getComponents( gbColArr );
+		style.getBackgroundColor().getComponents( gbColArr );
 		glClearColor( gbColArr[ 0 ], gbColArr[ 1 ], gbColArr[ 2 ], gbColArr[ 3 ] );
 		glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -1,8 +1,23 @@
 package org.mastodon.grapher.opengl;
 
+import static org.lwjgl.opengl.GL.createCapabilities;
+import static org.lwjgl.opengl.GL11.GL_BLEND;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_CULL_FACE;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_TEST;
+import static org.lwjgl.opengl.GL11.GL_MODELVIEW;
+import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.GL_PROJECTION;
+import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.glBlendFunc;
 import static org.lwjgl.opengl.GL11.glClear;
 import static org.lwjgl.opengl.GL11.glClearColor;
+import static org.lwjgl.opengl.GL11.glDisable;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glLoadIdentity;
+import static org.lwjgl.opengl.GL11.glMatrixMode;
+import static org.lwjgl.opengl.GL11.glOrtho;
+import static org.lwjgl.opengl.GL11.glViewport;
 import static org.lwjgl.opengl.GL11C.GL_DEPTH_BUFFER_BIT;
 
 import java.awt.Color;
@@ -19,8 +34,6 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelListener;
 
-import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.awt.AWTGLCanvas;
 import org.mastodon.grapher.opengl.overlays.GLOverlayRenderer;
 import org.mastodon.views.grapher.datagraph.ScreenTransform;
@@ -174,14 +187,14 @@ public class PointCloudCanvas extends AWTGLCanvas
 	@Override
 	public void initGL()
 	{
-		GL.createCapabilities();
+		createCapabilities();
 		
-		GL11.glDisable( GL11.GL_DEPTH_TEST );
-		GL11.glDisable( GL11.GL_CULL_FACE );
+		glDisable( GL_DEPTH_TEST );
+		glDisable( GL_CULL_FACE );
 
 		// Set transparency capabilities.
-		GL11.glEnable( GL11.GL_BLEND );
-		GL11.glBlendFunc( GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA );
+		glEnable( GL_BLEND );
+		glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
 		overlayRenderers.list.forEach( r -> r.init() );
 	}
@@ -189,17 +202,17 @@ public class PointCloudCanvas extends AWTGLCanvas
 	@Override
 	public void paintGL()
 	{
-		GL.createCapabilities();
+		createCapabilities();
 		final float[] gbColArr = new float[ 4 ];
 		BACKGROUND_COLOR.getComponents( gbColArr );
 		glClearColor( gbColArr[ 0 ], gbColArr[ 1 ], gbColArr[ 2 ], gbColArr[ 3 ] );
 		glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
-		GL11.glMatrixMode( GL11.GL_PROJECTION );
-		GL11.glLoadIdentity();
-		GL11.glOrtho( t.getMinX(), t.getMaxX(), t.getMinY(), t.getMaxY(), -1, 1 );
-		GL11.glViewport( 0, 0, getFramebufferWidth(), getFramebufferHeight() );
-		GL11.glMatrixMode( GL11.GL_MODELVIEW );
+		glMatrixMode( GL_PROJECTION );
+		glLoadIdentity();
+		glOrtho( t.getMinX(), t.getMaxX(), t.getMinY(), t.getMaxY(), -1, 1 );
+		glViewport( 0, 0, getFramebufferWidth(), getFramebufferHeight() );
+		glMatrixMode( GL_MODELVIEW );
 
 		overlayRenderers.list.forEach( r -> r.paint() );
 

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudCanvas.java
@@ -66,9 +66,9 @@ public class PointCloudCanvas extends AWTGLCanvas
 		{
 			final int w = getWidth();
 			final int h = getHeight();
-			final java.awt.geom.AffineTransform transform = PointCloudCanvas.this.getGraphicsConfiguration().getDefaultTransform();
-			final float sx = ( float ) transform.getScaleX();
-			final float sy = ( float ) transform.getScaleY();
+			final java.awt.geom.AffineTransform awtTransform = PointCloudCanvas.this.getGraphicsConfiguration().getDefaultTransform();
+			final float sx = ( float ) awtTransform.getScaleX();
+			final float sy = ( float ) awtTransform.getScaleY();
 			frameBufferWidth = ( int ) ( w * sx );
 			frameBufferHeight = ( int ) ( h * sy );
 			overlayRenderers.list.forEach( r -> r.setCanvasSize( w, h ) );

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudPanel.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudPanel.java
@@ -28,6 +28,7 @@ import org.mastodon.views.context.ContextListener;
 import org.mastodon.views.grapher.datagraph.ScreenTransform;
 import org.mastodon.views.grapher.display.FeatureGraphConfig;
 import org.mastodon.views.grapher.display.ScreenTransformState;
+import org.mastodon.views.grapher.display.style.DataDisplayStyle;
 
 import bdv.viewer.TransformListener;
 import bdv.viewer.render.PainterThread;
@@ -92,7 +93,7 @@ public class PointCloudPanel extends JPanel implements Paintable, ContextListene
 		setPreferredSize( new Dimension( w, h ) );
 
 		// Core canvas and painter thread.
-		this.canvas = new PointCloudCanvas();
+		this.canvas = new PointCloudCanvas( layout.getStyle() );
 		this.painterThread = new PainterThread( this );
 
 		// Screen transform.
@@ -290,7 +291,7 @@ public class PointCloudPanel extends JPanel implements Paintable, ContextListene
 		@Override
 		protected void paintComponent( final Graphics g )
 		{
-			final Color bgColor = PointCloudCanvas.BACKGROUND_COLOR;
+			final Color bgColor = layout.getStyle().getBackgroundColor();
 			final Color fgColor = Color.BLACK;
 			final Font tickFont = getFont().deriveFont( getFont().getSize2D() - 2f );
 			final Font labelFont = getFont(); // .deriveFont( Font.BOLD );
@@ -381,7 +382,7 @@ public class PointCloudPanel extends JPanel implements Paintable, ContextListene
 		@Override
 		protected void paintComponent( final Graphics g )
 		{
-			final Color bgColor = PointCloudCanvas.BACKGROUND_COLOR;
+			final Color bgColor = layout.getStyle().getBackgroundColor();
 			final Color fgColor = Color.BLACK;
 			final Font tickFont = getFont().deriveFont( getFont().getSize2D() - 2f );
 			final Font labelFont = getFont(); // .deriveFont( Font.BOLD );

--- a/src/main/java/org/mastodon/grapher/opengl/PointCloudPanel.java
+++ b/src/main/java/org/mastodon/grapher/opengl/PointCloudPanel.java
@@ -111,8 +111,8 @@ public class PointCloudPanel extends JPanel implements Paintable, ContextListene
 		canvas.overlays().add( highlightOverlay );
 
 		// Bottom axis.
-		final JPanel xAxis = new MyXAxisPanel( canvas.t );
-		final JPanel yAxis = new MyYAxisPanel( canvas.t );
+		final JPanel xAxis = new MyXAxisPanel( canvas.transform );
+		final JPanel yAxis = new MyYAxisPanel( canvas.transform );
 
 		// Add main canvas.
 		final JPanel mainPanel = new JPanel();
@@ -174,15 +174,15 @@ public class PointCloudPanel extends JPanel implements Paintable, ContextListene
 
 		// adjust scrollbars sizes
 		xScrollScale = 10000.0 / ( layoutMaxX - layoutMinX + 2 );
-		final int xval = ( int ) ( xScrollScale * canvas.t.getMinX() );
-		final int xext = ( int ) ( xScrollScale * ( canvas.t.getMaxX() - canvas.t.getMinX() ) );
+		final int xval = ( int ) ( xScrollScale * canvas.transform.getMinX() );
+		final int xext = ( int ) ( xScrollScale * ( canvas.transform.getMaxX() - canvas.transform.getMinX() ) );
 		final int xmin = ( int ) ( xScrollScale * layoutMinX );
 		final int xmax = ( int ) ( xScrollScale * layoutMaxX );
 		yScrollScale = 10000.0 / ( layoutMaxY - layoutMinY + 2 );
-		final int yext = ( int ) ( yScrollScale * ( canvas.t.getMaxY() - canvas.t.getMinY() ) );
+		final int yext = ( int ) ( yScrollScale * ( canvas.transform.getMaxY() - canvas.transform.getMinY() ) );
 		final int ymin = ( int ) ( yScrollScale * layoutMinY );
 		final int ymax = ( int ) ( yScrollScale * layoutMaxY );
-		final int yval = ( int ) ( yScrollScale * ( layoutMinY + layoutMaxY - canvas.t.getMaxY() ) );
+		final int yval = ( int ) ( yScrollScale * ( layoutMinY + layoutMaxY - canvas.transform.getMaxY() ) );
 
 		ignoreScrollBarChanges = true;
 		xScrollBar.setValues( xval, xext, xmin, xmax );

--- a/src/main/java/org/mastodon/grapher/opengl/overlays/DataEdgesOverlay.java
+++ b/src/main/java/org/mastodon/grapher/opengl/overlays/DataEdgesOverlay.java
@@ -1,6 +1,25 @@
 package org.mastodon.grapher.opengl.overlays;
 
-import org.lwjgl.opengl.GL33;
+import static org.lwjgl.opengl.GL11.GL_COLOR_ARRAY;
+import static org.lwjgl.opengl.GL11.GL_FLOAT;
+import static org.lwjgl.opengl.GL11.GL_LINES;
+import static org.lwjgl.opengl.GL11.GL_UNSIGNED_INT;
+import static org.lwjgl.opengl.GL11.GL_VERTEX_ARRAY;
+import static org.lwjgl.opengl.GL11.glColorPointer;
+import static org.lwjgl.opengl.GL11.glDisableClientState;
+import static org.lwjgl.opengl.GL11.glDrawElements;
+import static org.lwjgl.opengl.GL11.glEnableClientState;
+import static org.lwjgl.opengl.GL11.glVertexPointer;
+import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL15.GL_ELEMENT_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.glBindBuffer;
+import static org.lwjgl.opengl.GL15.glBufferData;
+import static org.lwjgl.opengl.GL15.glGenBuffers;
+import static org.lwjgl.opengl.GL20.glDisableVertexAttribArray;
+import static org.lwjgl.opengl.GL20.glEnableVertexAttribArray;
+import static org.lwjgl.opengl.GL20.glVertexAttribPointer;
+
 import org.mastodon.grapher.opengl.DataLayoutMaker;
 import org.mastodon.grapher.opengl.DataLayoutMaker.DataColor;
 import org.mastodon.grapher.opengl.DataLayoutMaker.DataLayout;
@@ -62,9 +81,9 @@ public class DataEdgesOverlay implements GLOverlayRenderer
 	public void init()
 	{
 		// New handles.
-		this.vboEdgePositionHandle = GL33.glGenBuffers();
-		this.iboEdgeIndexHandle = GL33.glGenBuffers();
-		this.vboEdgeColorHandle = GL33.glGenBuffers();
+		this.vboEdgePositionHandle = glGenBuffers();
+		this.iboEdgeIndexHandle = glGenBuffers();
+		this.vboEdgeColorHandle = glGenBuffers();
 	}
 
 	@Override
@@ -75,64 +94,64 @@ public class DataEdgesOverlay implements GLOverlayRenderer
 			updateXY = false;
 
 			// Update edge indices.
-			GL33.glBindBuffer( GL33.GL_ELEMENT_ARRAY_BUFFER, iboEdgeIndexHandle );
-			GL33.glBufferData( GL33.GL_ELEMENT_ARRAY_BUFFER, edgeIndexData, GL33.GL_STATIC_DRAW );
-			GL33.glBindBuffer( GL33.GL_ELEMENT_ARRAY_BUFFER, 0 );
+			glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, iboEdgeIndexHandle );
+			glBufferData( GL_ELEMENT_ARRAY_BUFFER, edgeIndexData, GL_STATIC_DRAW );
+			glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 );
 
 			// Update edge position.
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboEdgePositionHandle );
-			GL33.glBufferData( GL33.GL_ARRAY_BUFFER, edgePosData, GL33.GL_STATIC_DRAW );
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+			glBindBuffer( GL_ARRAY_BUFFER, vboEdgePositionHandle );
+			glBufferData( GL_ARRAY_BUFFER, edgePosData, GL_STATIC_DRAW );
+			glBindBuffer( GL_ARRAY_BUFFER, 0 );
 		}
 		if ( updateColor )
 		{
 			updateColor = false;
 
 			// Update edge colors.
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboEdgeColorHandle );
-			GL33.glBufferData( GL33.GL_ARRAY_BUFFER, edgesColorData, GL33.GL_STATIC_DRAW );
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+			glBindBuffer( GL_ARRAY_BUFFER, vboEdgeColorHandle );
+			glBufferData( GL_ARRAY_BUFFER, edgesColorData, GL_STATIC_DRAW );
+			glBindBuffer( GL_ARRAY_BUFFER, 0 );
 		}
 
 		/*
 		 * Enable.
 		 */
 
-		GL33.glEnableClientState( GL33.GL_VERTEX_ARRAY );
-		GL33.glEnableClientState( GL33.GL_COLOR_ARRAY );
+		glEnableClientState( GL_VERTEX_ARRAY );
+		glEnableClientState( GL_COLOR_ARRAY );
 
 		/*
 		 * Draw edges.
 		 */
 
 		// Enable and set the position attribute.
-		GL33.glEnableVertexAttribArray( 1 );
-		GL33.glVertexAttribPointer( 1, VERTEX_SIZE, GL33.GL_FLOAT, false, 0, 0 );
+		glEnableVertexAttribArray( 1 );
+		glVertexAttribPointer( 1, VERTEX_SIZE, GL_FLOAT, false, 0, 0 );
 
 		// Edge positions.
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboEdgePositionHandle );
-		GL33.glVertexPointer( VERTEX_SIZE, GL33.GL_FLOAT, 0, 0 );
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, vboEdgePositionHandle );
+		glVertexPointer( VERTEX_SIZE, GL_FLOAT, 0, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, 0 );
 
 		// Edge colors.
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboEdgeColorHandle );
-		GL33.glColorPointer( COLOR_SIZE, GL33.GL_FLOAT, 0, 0 );
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, vboEdgeColorHandle );
+		glColorPointer( COLOR_SIZE, GL_FLOAT, 0, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, 0 );
 
 		// Draw the line segments using the indices.
-		GL33.glBindBuffer( GL33.GL_ELEMENT_ARRAY_BUFFER, iboEdgeIndexHandle );
-		GL33.glDrawElements( GL33.GL_LINES, edgeIndexData.length, GL33.GL_UNSIGNED_INT, 0 );
-		GL33.glBindBuffer( GL33.GL_ELEMENT_ARRAY_BUFFER, 0 );
+		glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, iboEdgeIndexHandle );
+		glDrawElements( GL_LINES, edgeIndexData.length, GL_UNSIGNED_INT, 0 );
+		glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 );
 
 		// Disable the position attribute.
-		GL33.glDisableVertexAttribArray( 1 );
+		glDisableVertexAttribArray( 1 );
 
 		/*
 		 * Disable.
 		 */
 
-		GL33.glDisableClientState( GL33.GL_COLOR_ARRAY );
-		GL33.glDisableClientState( GL33.GL_VERTEX_ARRAY );
+		glDisableClientState( GL_COLOR_ARRAY );
+		glDisableClientState( GL_VERTEX_ARRAY );
 	}
 
 	public void draw( final DataLayout l )

--- a/src/main/java/org/mastodon/grapher/opengl/overlays/DataPointsOverlay.java
+++ b/src/main/java/org/mastodon/grapher/opengl/overlays/DataPointsOverlay.java
@@ -1,6 +1,21 @@
 package org.mastodon.grapher.opengl.overlays;
 
-import org.lwjgl.opengl.GL33;
+import static org.lwjgl.opengl.GL11.GL_COLOR_ARRAY;
+import static org.lwjgl.opengl.GL11.GL_FLOAT;
+import static org.lwjgl.opengl.GL11.GL_POINTS;
+import static org.lwjgl.opengl.GL11.GL_VERTEX_ARRAY;
+import static org.lwjgl.opengl.GL11.glColorPointer;
+import static org.lwjgl.opengl.GL11.glDisableClientState;
+import static org.lwjgl.opengl.GL11.glDrawArrays;
+import static org.lwjgl.opengl.GL11.glEnableClientState;
+import static org.lwjgl.opengl.GL11.glPointSize;
+import static org.lwjgl.opengl.GL11.glVertexPointer;
+import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.glBindBuffer;
+import static org.lwjgl.opengl.GL15.glBufferData;
+import static org.lwjgl.opengl.GL15.glGenBuffers;
+
 import org.mastodon.grapher.opengl.DataLayoutMaker;
 import org.mastodon.grapher.opengl.DataLayoutMaker.DataColor;
 import org.mastodon.grapher.opengl.DataLayoutMaker.DataLayout;
@@ -84,64 +99,64 @@ public class DataPointsOverlay implements GLOverlayRenderer
 	public void init()
 	{
 		// New handles.
-		this.vboVertexPositionHandle = GL33.glGenBuffers();
-		this.vboVertexColorHandle = GL33.glGenBuffers();
+		this.vboVertexPositionHandle = glGenBuffers();
+		this.vboVertexColorHandle = glGenBuffers();
 	}
 
 	@Override
 	public void paint()
 	{
-		GL33.glPointSize( DEFAULT_POINT_SIZE );
+		glPointSize( DEFAULT_POINT_SIZE );
 
 		if ( updateXY )
 		{
 			updateXY = false;
 
 			// Update vertex XY.
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexPositionHandle );
-			GL33.glBufferData( GL33.GL_ARRAY_BUFFER, vertexPosData, GL33.GL_STATIC_DRAW );
-			GL33.glVertexPointer( VERTEX_NUM_DIMENSIONS, GL33.GL_FLOAT, 0, 0 );
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+			glBindBuffer( GL_ARRAY_BUFFER, vboVertexPositionHandle );
+			glBufferData( GL_ARRAY_BUFFER, vertexPosData, GL_STATIC_DRAW );
+			glVertexPointer( VERTEX_NUM_DIMENSIONS, GL_FLOAT, 0, 0 );
+			glBindBuffer( GL_ARRAY_BUFFER, 0 );
 		}
 		if ( updateColor )
 		{
 			updateColor = false;
 
 			// Vertex colors.
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexColorHandle );
-			GL33.glBufferData( GL33.GL_ARRAY_BUFFER, vertexColorData, GL33.GL_STATIC_DRAW );
-			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+			glBindBuffer( GL_ARRAY_BUFFER, vboVertexColorHandle );
+			glBufferData( GL_ARRAY_BUFFER, vertexColorData, GL_STATIC_DRAW );
+			glBindBuffer( GL_ARRAY_BUFFER, 0 );
 		}
 
 		/*
 		 * Enable.
 		 */
 
-		GL33.glEnableClientState( GL33.GL_VERTEX_ARRAY );
-		GL33.glEnableClientState( GL33.GL_COLOR_ARRAY );
+		glEnableClientState( GL_VERTEX_ARRAY );
+		glEnableClientState( GL_COLOR_ARRAY );
 
 		/*
 		 * Draw vertices.
 		 */
 
 		// Vertex colors.
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexPositionHandle );
-		GL33.glVertexPointer( VERTEX_NUM_DIMENSIONS, GL33.GL_FLOAT, 0, 0 );
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, vboVertexPositionHandle );
+		glVertexPointer( VERTEX_NUM_DIMENSIONS, GL_FLOAT, 0, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, 0 );
 
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexColorHandle );
-		GL33.glColorPointer( COLOR_NUM_CHANNELS, GL33.GL_FLOAT, 0, 0 );
-		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, vboVertexColorHandle );
+		glColorPointer( COLOR_NUM_CHANNELS, GL_FLOAT, 0, 0 );
+		glBindBuffer( GL_ARRAY_BUFFER, 0 );
 
 		// Draw vertices as points.
-		GL33.glDrawArrays( GL33.GL_POINTS, 0, vertexPosData.length / VERTEX_NUM_DIMENSIONS );
+		glDrawArrays( GL_POINTS, 0, vertexPosData.length / VERTEX_NUM_DIMENSIONS );
 
 		/*
 		 * Disable.
 		 */
 
-		GL33.glDisableClientState( GL33.GL_COLOR_ARRAY );
-		GL33.glDisableClientState( GL33.GL_VERTEX_ARRAY );
+		glDisableClientState( GL_COLOR_ARRAY );
+		glDisableClientState( GL_VERTEX_ARRAY );
 	}
 
 	public void draw( final DataLayout l )

--- a/src/main/java/org/mastodon/grapher/opengl/overlays/DataPointsOverlay.java
+++ b/src/main/java/org/mastodon/grapher/opengl/overlays/DataPointsOverlay.java
@@ -11,9 +11,9 @@ import org.scijava.listeners.Listeners;
 public class DataPointsOverlay implements GLOverlayRenderer
 {
 
-	public static final int VERTEX_SIZE = 2; // X, Y
+	public static final int VERTEX_NUM_DIMENSIONS = 2; // X, Y
 
-	public static final int COLOR_SIZE = 4; // R, G, B, alpha
+	public static final int COLOR_NUM_CHANNELS = 4; // R, G, B, alpha
 
 	public static final float DEFAULT_POINT_SIZE = 5.1f;
 
@@ -100,7 +100,7 @@ public class DataPointsOverlay implements GLOverlayRenderer
 			// Update vertex XY.
 			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexPositionHandle );
 			GL33.glBufferData( GL33.GL_ARRAY_BUFFER, vertexPosData, GL33.GL_STATIC_DRAW );
-			GL33.glVertexPointer( VERTEX_SIZE, GL33.GL_FLOAT, 0, 0 );
+			GL33.glVertexPointer( VERTEX_NUM_DIMENSIONS, GL33.GL_FLOAT, 0, 0 );
 			GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
 		}
 		if ( updateColor )
@@ -126,15 +126,15 @@ public class DataPointsOverlay implements GLOverlayRenderer
 
 		// Vertex colors.
 		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexPositionHandle );
-		GL33.glVertexPointer( VERTEX_SIZE, GL33.GL_FLOAT, 0, 0 );
+		GL33.glVertexPointer( VERTEX_NUM_DIMENSIONS, GL33.GL_FLOAT, 0, 0 );
 		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
 
 		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, vboVertexColorHandle );
-		GL33.glColorPointer( COLOR_SIZE, GL33.GL_FLOAT, 0, 0 );
+		GL33.glColorPointer( COLOR_NUM_CHANNELS, GL33.GL_FLOAT, 0, 0 );
 		GL33.glBindBuffer( GL33.GL_ARRAY_BUFFER, 0 );
 
 		// Draw vertices as points.
-		GL33.glDrawArrays( GL33.GL_POINTS, 0, vertexPosData.length / VERTEX_SIZE );
+		GL33.glDrawArrays( GL33.GL_POINTS, 0, vertexPosData.length / VERTEX_NUM_DIMENSIONS );
 
 		/*
 		 * Disable.


### PR DESCRIPTION
This PR changes the behaviour of the Open GL grapher such that it does not use a static greyish color as background, but the background color that the user has set in the User preferences dialog. Thereby the behaviour of the OpenGL grapher is streamlined a bit more to the behaviour of the existing grapher.

Further changes by this PR:

* Change pom-scijava to 38.0.1. Earlier versions of pom-scijava lead to a NullPointerException of the Maven Enforcer Plugin during maven package
* ~Add a plugin so that the Open GL Grapher can be opened by the user from the Plugins menu.~
* Import GL methods as static methods and use them without GLnn version nomenclature in the code
* Rename some variables to increase code readability (may be subjective).